### PR TITLE
line breaks in preformatted text

### DIFF
--- a/src/gemtext.rs
+++ b/src/gemtext.rs
@@ -153,6 +153,7 @@ pub fn parse_gemtext(lines: &[String]) -> Vec<GemtextToken> {
                 });
             } else {
                 pft_block.push_str(&line);
+                pft_block.push_str("\r");
             }
         }
     }


### PR DESCRIPTION
This resolves issue [preformated text #2](https://github.com/genericlastname/crosspub/issues/2)